### PR TITLE
introduce HTTPS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Added
+* HTTPS server with self-signed certificate
+
+
 ## 0.1.0
 
 ### Added
@@ -18,6 +24,7 @@
 * Warning generation function
 * Fix sensing response headers (Content-Type: JSON)
 * Correct data structure for "swupdate2"
+
 
 ## 0.0.7 - 2019-02-13
 

--- a/huebridge.html
+++ b/huebridge.html
@@ -44,7 +44,12 @@
 
     <div class="form-row">
         <label for="node-config-input-port"><i class="fa fa-globe"></i> <span data-i18n="huebridge.label.port"></span></label>
-        <input type="text" id="node-config-input-port" 80>
+        <input type="text" id="node-config-input-port" data-i18n="[placeholder]huebridge.placeholder.port" 80>
+    </div>
+
+    <div class="form-row">
+        <label for="node-config-input-port"><i class="fa fa-globe"></i> <span data-i18n="huebridge.label.sslPort"></span></label>
+        <input type="text" id="node-config-input-sslPort" data-i18n="[placeholder]huebridge.placeholder.sslPort">
     </div>
 
     <div class="form-row">
@@ -94,6 +99,9 @@
             },
             port: {
                 value: 80, required: true, validate: RED.validators.number(true)
+            },
+            sslPort: {
+                value: null, required: false, validate: RED.validators.number(true)
             },
             extAddress: {
                 value: '', required:false

--- a/huebridge.js
+++ b/huebridge.js
@@ -73,7 +73,7 @@ module.exports = function (RED) {
             return;
         }
 
-        this.bridge = new Bridge(address, netmask, gateway, mac, config.port, config.extAddress, config.extPort);
+        this.bridge = new Bridge(address, netmask, gateway, mac, config.port, config.sslPort, config.extAddress, config.extPort);
         this.bridge.debugFn = RED.log.debug;
         this.bridge.warnFn = RED.log.warn;
 

--- a/lib/Bridge.js
+++ b/lib/Bridge.js
@@ -22,6 +22,7 @@
 const Emitter = require('events').EventEmitter;
 const stoppable = require('stoppable');
 const http = require('http');
+const https = require('https');
 
 const Aggregation = require('./Aggregation.js');
 const Lights = require('./Lights.js');
@@ -36,6 +37,7 @@ const Capabilities = require('./Capabilities');
 const Datastore = require('./Datastore.js');
 const RuleEngine = require('./RuleEngine.js');
 const SSDP = require('./Ssdp.js');
+const CA = require('./CA.js');
 
 /**
  * The emulated Bridge class.
@@ -49,14 +51,16 @@ class Bridge extends Aggregation(Lights, Groups, Schedules, Scenes, Sensors, Rul
      * @param {string} gateway    Network gateway.
      * @param {string} mac        MAC address.
      * @param {number} port       HTTP port to listen on.
+     * @param {number} sslPort    HTTPS port to listen on.
      * @param {string} extAddress External address (optional)
      * @param {number} extPort    Externally reported HTTP port (optional).
      */
-    constructor(address, netmask, gateway, mac, port, extAddress, extPort) {
+    constructor(address, netmask, gateway, mac, port, sslPort, extAddress, extPort) {
         super();
 
         this.dsSetNetwork(address, netmask, gateway, mac);
         this.dsSetHttpPort(port);
+        this.dsSetHttpsPort(sslPort);
         this.dsSetExternalAddress(extAddress);
         this.dsSetExternalPort(extPort);
 
@@ -70,72 +74,9 @@ class Bridge extends Aggregation(Lights, Groups, Schedules, Scenes, Sensors, Rul
     start() {
         const graceMilliseconds = 500;
 
-        this.httpServer = stoppable(http.createServer((request, response) => {
-            var obj = {};
-            var urlParts = request.url.split('/');
-            var method = request.method.toLowerCase();
+        this.httpServer = stoppable(http.createServer((req, res) => this._requestListener(req, res)), graceMilliseconds);
 
-            this.debug('Bridge::httpServer(request): method = ' + method);
-            this.debug('Bridge::httpServer(request): url    = ' + request.url);
-
-            if (method === 'post' || method === 'put') {
-                var body = [];
-                request.on('data', (chunk) => {
-                    body.push(chunk);
-                }).on('end', () => {
-                    body = Buffer.concat(body).toString();
-                    this.debug('Bridge::httpServer(request): body = ' + body);
-
-                    if (body.length > 1) {
-                        try {
-                            obj = JSON.parse(body);
-                        } catch (err) {
-                            this.debug('Bridge::httpServer(request): JSON error = ' + err);
-                        }
-                    }
-
-                    this.dispatch(response, method, request.url, urlParts, obj);
-                });
-            } else if (method === 'get') {
-                this.dispatch(response, method, request.url, urlParts, obj);
-            } else if (method === 'delete') {
-                this.dispatch(response, method, request.url, urlParts, obj);
-            } else {
-                this.debug('Bridge::httpServer(request): unsupported method');
-
-                response.writeHead(404);
-                response.end();
-            }
-        }), graceMilliseconds);
-
-        this.httpServer.on(
-            'error',
-            (error) => {
-                if (!error) {
-                    this.warn('Bridge::httpServer(on-error): unable to start');
-                    this.emit('http-error', 'unable to start; no error message');
-                    return;
-                }
-
-                var errorCode = null;
-                if (error.code) {
-                    errorCode = error.code;
-                } else if (error.errno) {
-                    errorCode = error.errno;
-                }
-
-                var errorText = '';
-                if (errorCode) {
-                    errorText += errorCode;
-                } else {
-                    errorText += 'unable to start [1]';
-                }
-                errorText += ' (p:' + this.dsGetHttpPort() + ')';
-
-                this.warn('Bridge::httpServer(on-error): ' + errorText);
-                this.emit('http-error', errorText);
-            }
-        );
+        this.httpServer.on('error', (err) => this._onError(err));
 
         // start server
         this.httpServer.listen(
@@ -155,6 +96,44 @@ class Bridge extends Aggregation(Lights, Groups, Schedules, Scenes, Sensors, Rul
                 this.ssdpStart(actualPort);
             }
         );
+
+        // Is HTTPS configured?
+        const httpsPort = this.dsGetHttpsPort();
+        if (typeof httpsPort !== 'undefined' && httpsPort > 0) {
+            CA.generateKeyPair(this.dsGetMAC()).then(
+                (options) => {
+                    this.debug('Bridge::start(): Starting HTTPS server');
+
+                    this.httpsServer = stoppable(
+                        https.createServer(
+                            options,
+                            (req, res) => this._requestListener(req, res)
+                        ),
+                        graceMilliseconds
+                    );
+                    this.httpsServer.on('error', (err) => this._onError(err));
+                    this.httpsServer.listen(
+                        httpsPort,
+                        (error) => {
+                            if (error) {
+                                this.warn('Bridge::httpsServer(listen): ' + JSON.stringify(error));
+                                this.emit('http-error', error);
+                                return;
+                            }
+
+                            // extract the actual port number that was used
+                            const actualPort = this.httpsServer.address().port;
+                            this.debug('Bridge::httpsServer(listen): actualPort = ' + actualPort);
+
+                            // start discovery service after we know the port number
+                            this.ssdpStart(actualPort);
+                        }
+                    );
+                },
+                (err) => this.warn('Bridge::start(): SSL key pair generation failed, not starting HTTPS server: ' + err)
+            )
+
+        }
 
         this.debug('Bridge::start(): staring engines');
         this.ruleEngine();
@@ -183,6 +162,19 @@ class Bridge extends Aggregation(Lights, Groups, Schedules, Scenes, Sensors, Rul
         });
 
         setImmediate(() => this.httpServer.emit('close'));
+
+        this.httpsServer.stop(() => {
+            this.debug('Bridge::stop(httpsServer-stop): begin');
+
+            if (typeof done === 'function') {
+                done();
+                this.debug('Bridge::stop(): done ...');
+            }
+
+            this.debug('Bridge::stop(httpsServer-stop): end');
+        });
+
+        setImmediate(() => this.httpsServer.emit('close'));
 
         this.debug('Bridge::stop(): end');
     }
@@ -395,6 +387,83 @@ class Bridge extends Aggregation(Lights, Groups, Schedules, Scenes, Sensors, Rul
                     return v;
                 }
             });
+    }
+
+    /**
+     * HTTP(S) request listener.
+     *
+     * @param {*} request  HTTP request.
+     * @param {*} response HTTP response.
+     * @private
+     */
+    _requestListener(request, response) {
+        var obj = {};
+        var urlParts = request.url.split('/');
+        var method = request.method.toLowerCase();
+
+        this.debug('Bridge::httpServer(request): method = ' + method);
+        this.debug('Bridge::httpServer(request): url    = ' + request.url);
+
+        if (method === 'post' || method === 'put') {
+            var body = [];
+            request.on('data', (chunk) => {
+                body.push(chunk);
+            }).on('end', () => {
+                body = Buffer.concat(body).toString();
+                this.debug('Bridge::httpServer(request): body = ' + body);
+
+                if (body.length > 1) {
+                    try {
+                        obj = JSON.parse(body);
+                    } catch (err) {
+                        this.debug('Bridge::httpServer(request): JSON error = ' + err);
+                    }
+                }
+
+                this.dispatch(response, method, request.url, urlParts, obj);
+            });
+        } else if (method === 'get') {
+            this.dispatch(response, method, request.url, urlParts, obj);
+        } else if (method === 'delete') {
+            this.dispatch(response, method, request.url, urlParts, obj);
+        } else {
+            this.debug('Bridge::httpServer(request): unsupported method');
+
+            response.writeHead(404);
+            response.end();
+        }
+    }
+
+    /**
+     * HTTP(S) error listener.
+     *
+     * @param {*} error Error object.
+     * @private
+     */
+    _onError(error) {
+        if (!error) {
+            this.warn('Bridge::httpServer(on-error): unable to start');
+            this.emit('http-error', 'unable to start; no error message');
+            return;
+        }
+
+        var errorCode = null;
+        if (error.code) {
+            errorCode = error.code;
+        } else if (error.errno) {
+            errorCode = error.errno;
+        }
+
+        var errorText = '';
+        if (errorCode) {
+            errorText += errorCode;
+        } else {
+            errorText += 'unable to start [1]';
+        }
+        errorText += ' (p:' + this.dsGetHttpPort() + ')';
+
+        this.warn('Bridge::httpServer(on-error): ' + errorText);
+        this.emit('http-error', errorText);
     }
 
     /**

--- a/lib/Bridge.js
+++ b/lib/Bridge.js
@@ -124,9 +124,6 @@ class Bridge extends Aggregation(Lights, Groups, Schedules, Scenes, Sensors, Rul
                             // extract the actual port number that was used
                             const actualPort = this.httpsServer.address().port;
                             this.debug('Bridge::httpsServer(listen): actualPort = ' + actualPort);
-
-                            // start discovery service after we know the port number
-                            this.ssdpStart(actualPort);
                         }
                     );
                 },

--- a/lib/CA.js
+++ b/lib/CA.js
@@ -1,0 +1,125 @@
+/**
+ * NodeRED Hue Bridge
+ * Copyright (C) 2020 Stefan Kalscheuer.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+'use strict';
+
+const openssl = require('openssl-nodejs-promise');
+
+/**
+ * The emulated Bridge class.
+ */
+class CA {
+    static get OPENSSL_CONF() {
+        return Buffer.from(
+            '[ req ]\n' +
+            'default_bits            = 1024\n' +
+            'default_md              = sha256\n' +
+            'distinguished_name      = req_distinguished_name\n' +
+            'attributes              = req_attributes\n' +
+            'req_extensions  = v3_req\n' +
+            'x509_extensions = usr_cert\n' +
+            '\n' +
+            '\n' +
+            '[ usr_cert ]\n' +
+            'basicConstraints=critical,CA:FALSE\n' +
+            'subjectKeyIdentifier=hash\n' +
+            'authorityKeyIdentifier=keyid,issuer\n' +
+            'keyUsage = critical, digitalSignature, keyEncipherment\n' +
+            'extendedKeyUsage = serverAuth\n' +
+            '\n' +
+            '[ v3_req ]\n' +
+            'extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection\n' +
+            'basicConstraints = CA:FALSE\n' +
+            'keyUsage = nonRepudiation, digitalSignature, keyEncipherment\n' +
+            '\n' +
+            '[ req_distinguished_name ]\n' +
+            '\n' +
+            '[ req_attributes ]\n'
+        );
+    }
+
+    /**
+     * Generate a self-signed key pair.
+     *
+     * @param {string} mac MAC address of the bridge.
+     * @return {Promise<*>} Promise of object containing key and cert.
+     */
+    static generateKeyPair(mac) {
+        return new Promise((resolve, reject) => {
+            const m = mac.toLowerCase().split(':');
+            const serial = m[0] + m[1] + m[2] + 'fffe' + m[3] + m[4] + m[5];
+            const decSerial = BigInt('0x' + serial).toString(10);
+
+            openssl(
+                [
+                    'req',
+                    '-new',
+                    '-config', {name: 'huebridge.conf', buffer: CA.OPENSSL_CONF},
+                    '-nodes',
+                    '-x509',
+                    '-newkey', 'ec',
+                    '-pkeyopt', 'ec_paramgen_curve:P-256',
+                    '-pkeyopt', 'ec_param_enc:named_curve',
+                    '-subj', '/C=NL/O=Philips Hue/CN=' + serial,
+                    '-set_serial', decSerial
+                ],
+                {
+                    dir: __dirname + '/..'
+                }
+            ).then(
+                (res) => {
+                    let key = '';
+                    let cert = '';
+                    let isKey = false;
+                    let isCert = false;
+                    for (let l of res.toString().split('\n')) {
+                        if (l === '-----BEGIN PRIVATE KEY-----') {
+                            key += l + '\n';
+                            isKey = true;
+                        } else if (isKey && l === '-----END PRIVATE KEY-----') {
+                            key += l + '\n';
+                            isKey = false;
+                        } else if (isKey) {
+                            key += l + '\n';
+                        } else if (l === '-----BEGIN CERTIFICATE-----') {
+                            cert += l + '\n';
+                            isCert = true;
+                        } else if (isCert && l === '-----END CERTIFICATE----') {
+                            cert += l + '\n';
+                            isCert = false;
+                        } else if (isCert) {
+                            cert += l + '\n';
+                        }
+                    }
+
+                    resolve({
+                        key: key,
+                        cert: cert
+                    });
+                },
+                (err) => {
+                    reject(err);
+                }
+            ).catch((err) => {
+                reject(err);
+            });
+        });
+    }
+}
+
+module.exports = CA;

--- a/lib/CA.js
+++ b/lib/CA.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-const openssl = require('openssl-nodejs-promise');
+const openssl = require('openssl-nodejs');
 
 /**
  * The emulated Bridge class.
@@ -78,46 +78,41 @@ class CA {
                     '-subj', '/C=NL/O=Philips Hue/CN=' + serial,
                     '-set_serial', decSerial
                 ],
-                {
-                    dir: __dirname + '/..'
-                }
-            ).then(
-                (res) => {
+                (stderr, stdout) => {
                     let key = '';
                     let cert = '';
-                    let isKey = false;
-                    let isCert = false;
-                    for (let l of res.toString().split('\n')) {
-                        if (l === '-----BEGIN PRIVATE KEY-----') {
+                    let keyState = 0;
+                    let certState = 0;
+                    for (let l of stdout.toString().split('\n')) {
+                        if (keyState === 0 && l === '-----BEGIN PRIVATE KEY-----') {
                             key += l + '\n';
-                            isKey = true;
-                        } else if (isKey && l === '-----END PRIVATE KEY-----') {
+                            keyState = 1;
+                        } else if (keyState === 1 && l === '-----END PRIVATE KEY-----') {
                             key += l + '\n';
-                            isKey = false;
-                        } else if (isKey) {
+                            keyState = 2;
+                        } else if (keyState === 1) {
                             key += l + '\n';
-                        } else if (l === '-----BEGIN CERTIFICATE-----') {
+                        } else if (certState === 0 && l === '-----BEGIN CERTIFICATE-----') {
                             cert += l + '\n';
-                            isCert = true;
-                        } else if (isCert && l === '-----END CERTIFICATE----') {
+                            certState = 1;
+                        } else if (certState === 1 && l === '-----END CERTIFICATE-----') {
                             cert += l + '\n';
-                            isCert = false;
-                        } else if (isCert) {
+                            certState = 2;
+                        } else if (certState === 1) {
                             cert += l + '\n';
                         }
                     }
 
-                    resolve({
-                        key: key,
-                        cert: cert
-                    });
-                },
-                (err) => {
-                    reject(err);
+                    if (keyState === 2 && certState === 2) {
+                        resolve({
+                            key: key,
+                            cert: cert
+                        });
+                    } else {
+                        reject(stderr.toString())
+                    }
                 }
-            ).catch((err) => {
-                reject(err);
-            });
+            );
         });
     }
 }

--- a/lib/Datastore.js
+++ b/lib/Datastore.js
@@ -1507,6 +1507,14 @@ class Datastore {
         return this.dsHttpPort;
     }
 
+    dsSetHttpsPort(port) {
+        this.dsHttpsPort = port;
+    }
+
+    dsGetHttpsPort() {
+        return this.dsHttpsPort;
+    }
+
     dsGetBridgeID() {
         return this.dsBridgeID;
     }

--- a/locales/en-US/huebridge.json
+++ b/locales/en-US/huebridge.json
@@ -6,7 +6,8 @@
             "address": "Address",
             "netmask": "Netmask",
             "gateway": "Gateway",
-            "port": "Port",
+            "port": "HTTP Port",
+            "sslPort": "HTTPS Port",
             "external-parameters": "Optional for Reverse Proxy compatibiltiy",
             "extAddress": "Ext. Address",
             "extPort": "Ext. Port",
@@ -16,6 +17,8 @@
         },
         "placeholder": {
             "name": "Name",
+            "port": "80",
+            "sslPort": "optional (e.g. 443)",
             "mac": "optional (xx:xx:xx:xx:xx:xx)"
         },
         "hint": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-huebridge",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha",
   "description": "Node-RED nodes to simulate Phillips Hue Bridge devices",
   "main": "huebridge.js",
   "scripts": {},
@@ -41,6 +41,7 @@
     "ip": "^1.1.5",
     "node-persist": "^2.1.0",
     "node-schedule": "^1.3.1",
+    "openssl-nodejs-promise": "^0.0.4",
     "peer-ssdp": "^0.0.5",
     "stoppable": "^1.1.0",
     "suncalc": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ip": "^1.1.5",
     "node-persist": "^2.1.0",
     "node-schedule": "^1.3.1",
-    "openssl-nodejs-promise": "^0.0.4",
+    "openssl-nodejs": "^1.0.5",
     "peer-ssdp": "^0.0.5",
     "stoppable": "^1.1.0",
     "suncalc": "^1.8.0"


### PR DESCRIPTION
Official Hue apps switch to HTTPS for communication after initial handshake as of bridge v1.24

We now utilize _OpenSSL_ to generate a self-signed elliptic curve certificate with bridge ID as common name and serial which matches the original implementation.

If an HTTPS port is specified, the certificate will be issued on startup and an HTTPS server is started.
All endpoints are exactly the same as for HTTP and the HTTPs port is exposed nowhere, i.e. one can rewrite or proxy the port as desired. Hue app searches on 443 on the same address as reported for 80.